### PR TITLE
Add elasticache-redis-cluster module

### DIFF
--- a/modules/elasticache-redis-cluster/README.md
+++ b/modules/elasticache-redis-cluster/README.md
@@ -1,0 +1,105 @@
+# elasticache-redis-cluster
+
+This module creates following resources.
+
+- `aws_elasticache_replication_group`
+- `aws_elasticache_parameter_group` (optional)
+- `aws_security_group` (optional)
+- `aws_security_group_rule` (optional)
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.30 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.34.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.10.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | tedilabs/network/aws//modules/security-group | ~> 0.26.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_elasticache_parameter_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_parameter_group) | resource |
+| [aws_elasticache_replication_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name"></a> [name](#input\_name) | (Required) The name of the ElastiCache Redis cluster. This parameter is stored as a lowercase string. | `string` | n/a | yes |
+| <a name="input_node_instance_type"></a> [node\_instance\_type](#input\_node\_instance\_type) | (Required) The instance type to be deployed for the ElastiCache Redis cluster. | `string` | n/a | yes |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | (Optional) Whether any modifications are applied immediately, or during the next maintenance window. Default to `false`. | `bool` | `false` | no |
+| <a name="input_auto_failover_enabled"></a> [auto\_failover\_enabled](#input\_auto\_failover\_enabled) | (Optional) Whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `node_size` must be greater than 1. Must be enabled for Redis (cluster mode enabled) cluster. Defaults to `false`. ElastiCache Auto Failover provides enhanced high availability through automatic failover to a read replica in case of a primary node failover. | `bool` | `false` | no |
+| <a name="input_auto_upgrade_minor_version_enabled"></a> [auto\_upgrade\_minor\_version\_enabled](#input\_auto\_upgrade\_minor\_version\_enabled) | (Optional) Whether automatically schedule cluster upgrade to the latest minor version, once it becomes available. Cluster upgrade will only be scheduled during the maintenance window. Defaults to `true`. Only supported if the redis version is 6 or higher. | `bool` | `true` | no |
+| <a name="input_backup_enabled"></a> [backup\_enabled](#input\_backup\_enabled) | (Optional) Whether to automatically create a daily backup of a set of replicas. Defaults to `false`. | `bool` | `false` | no |
+| <a name="input_backup_final_snapshot_name"></a> [backup\_final\_snapshot\_name](#input\_backup\_final\_snapshot\_name) | (Optional) The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made. | `string` | `null` | no |
+| <a name="input_backup_retention"></a> [backup\_retention](#input\_backup\_retention) | (Optional) The number of days for which automated backups are retained before they are automatically deleted. Valid value is between `1` and `35`. Defaults to 1. | `number` | `1` | no |
+| <a name="input_backup_window"></a> [backup\_window](#input\_backup\_window) | (Optional) The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of the ElastiCache Redis cluster. The minimum snapshot window is a 60 minute period. Example: 05:00-09:00. Defaults to `16:00-17:00`. | `string` | `"16:00-17:00"` | no |
+| <a name="input_custom_parameter_group"></a> [custom\_parameter\_group](#input\_custom\_parameter\_group) | (Optional) The name of the parameter group to associate with the ElastiCache Redis cluster. If this argument is omitted, the default cache parameter group for the specified engine is used. To enable `cluster mode` (sharding), use a parameter group that has the parameter `cluster-enabled` set to `true`. | `string` | `null` | no |
+| <a name="input_default_security_group"></a> [default\_security\_group](#input\_default\_security\_group) | (Optional) The configuration of the default security group for the ElastiCache Redis cluster. `default_security_group` block as defined below.<br>    (Optional) `enabled` - Whether to use the default security group. Defaults to `true`.<br>    (Optional) `name` - The name of the default security group. If not provided, the cluster name is used for the name of security group.<br>    (Optional) `description` - The description of the default security group.<br>    (Optional) `ingress_rules` - A list of ingress rules in a security group. You don't need to specify `protocol`, `from_port`, `to_port`. Just specify source information. Defauls to `[{ cidr_blocks = "0.0.0.0/0" }]`. | <pre>object({<br>    enabled     = optional(bool, true)<br>    name        = optional(string, null)<br>    description = optional(string, "Managed by Terraform.")<br>    ingress_rules = optional(any, [{<br>      cidr_blocks = ["0.0.0.0/0"]<br>    }])<br>  })</pre> | `{}` | no |
+| <a name="input_description"></a> [description](#input\_description) | (Optional) The description of the ElastiCache Redis cluster. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_encryption_at_rest"></a> [encryption\_at\_rest](#input\_encryption\_at\_rest) | The configuration for at-rest encryption of the ElastiCache Redis cluster.<br>    (Optional) `enabled` - Whether to enable at-rest encryption. Defaults to `false`.<br>    (Optional) `kms_key` - The ARN of the key to use for at-rest encryption. If not supplied, uses service managed encryption key. Can be specified only if `encryption_at_rest.enabled` is `true`. | <pre>object({<br>    enabled = optional(bool, false)<br>    kms_key = optional(string, null)<br>  })</pre> | `{}` | no |
+| <a name="input_encryption_in_transit"></a> [encryption\_in\_transit](#input\_encryption\_in\_transit) | The configuration for in-transit encryption of the ElastiCache Redis cluster.<br>    (Optional) `enabled` - Whether to enable in-transit encryption. Defaults to `false`. | <pre>object({<br>    enabled = optional(bool, false)<br>  })</pre> | `{}` | no |
+| <a name="input_logging_engine_log"></a> [logging\_engine\_log](#input\_logging\_engine\_log) | The configuration for streaming Redis Engine Log of the ElastiCache Redis cluster.<br>    (Optional) `enabled` - Whether to enable streaming Redis Engine Log. Defaults to `false`.<br>    (Optional) `format` - The format of Redis Engine Log. Valid values are `JSON` or `TEXT`. Defaults to `JSON`.<br>    (Optional) `destination_type` - The destination type for streaming Redis Engine Log. For CloudWatch Logs use `CLOUDWATCH_LOGS` or for Kinesis Data Firehose use `KINESIS_FIREHOSE`. Defaults to `CLOUDWATCH_LOGS`.<br>    (Optional) `destination` - The name of either the CloudWatch Logs LogGroup or Kinesis Data Firehose resource. | <pre>object({<br>    enabled          = optional(bool, false)<br>    format           = optional(string, "JSON")<br>    destination_type = optional(string, "CLOUDWATCH_LOGS")<br>    destination      = optional(string, null)<br>  })</pre> | `{}` | no |
+| <a name="input_logging_slow_log"></a> [logging\_slow\_log](#input\_logging\_slow\_log) | The configuration for streaming Redis Slow Log of the ElastiCache Redis cluster.<br>    (Optional) `enabled` - Whether to enable streaming Redis Slow Log. Defaults to `false`.<br>    (Optional) `format` - The format of Redis Slow Log. Valid values are `JSON` or `TEXT`. Defaults to `JSON`.<br>    (Optional) `destination_type` - The destination type for streaming Redis Slow Log. For CloudWatch Logs use `CLOUDWATCH_LOGS` or for Kinesis Data Firehose use `KINESIS_FIREHOSE`. Defaults to `CLOUDWATCH_LOGS`.<br>    (Optional) `destination` - The name of either the CloudWatch Logs LogGroup or Kinesis Data Firehose resource. | <pre>object({<br>    enabled          = optional(bool, false)<br>    format           = optional(string, "JSON")<br>    destination_type = optional(string, "CLOUDWATCH_LOGS")<br>    destination      = optional(string, null)<br>  })</pre> | `{}` | no |
+| <a name="input_maintenance_window"></a> [maintenance\_window](#input\_maintenance\_window) | (Optional) The weekly time range for when maintenance on the ElastiCache Redis cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`. Defaults to `fri:18:00-fri:20:00`. | `string` | `"fri:18:00-fri:20:00"` | no |
+| <a name="input_module_tags_enabled"></a> [module\_tags\_enabled](#input\_module\_tags\_enabled) | (Optional) Whether to create AWS Resource Tags for the module informations. | `bool` | `true` | no |
+| <a name="input_multi_az_enabled"></a> [multi\_az\_enabled](#input\_multi\_az\_enabled) | (Optional) Whether to enable Multi-AZ Support for the ElastiCache Redis cluster. If true, `auto_failover_enabled` must also be enabled. Defaults to `false`. | `bool` | `false` | no |
+| <a name="input_node_size"></a> [node\_size](#input\_node\_size) | (Optional) The number of cache nodes (primary and replicas) for this ElastiCache Redis cluster will have. If Multi-AZ is enabled, this value must be at least 2. Updates will occur before other modifications. Defaults to `1`. | `number` | `1` | no |
+| <a name="input_notification_sns_topic"></a> [notification\_sns\_topic](#input\_notification\_sns\_topic) | (Optional) The ARN of an SNS topic to send ElastiCache notifications to. | `string` | `null` | no |
+| <a name="input_parameter_group"></a> [parameter\_group](#input\_parameter\_group) | The configuration for parameter group of the ElastiCache Redis cluster.<br>    (Optional) `enabled` - Whether to enable managed parameter group by this module.<br>    (Optional) `name` - The name of the managed parameter group. If not provided, the name is configured with the cluster name.<br>    (Optional) `description` - The description of the managed parameter group.<br>    (Optional) `parameters` - The key/value set for Redis parameters of ElastiCache Redis cluster. Each key is the name of the redis parameter. Each value is the value of the redis parameter. | <pre>object({<br>    enabled     = optional(bool, true)<br>    name        = optional(string, "")<br>    description = optional(string, "")<br>    parameters  = optional(map(string), {})<br>  })</pre> | `{}` | no |
+| <a name="input_password"></a> [password](#input\_password) | (Optional) Password used to access a password protected ElastiCache Redis cluster. Can be specified only if `encryption_in_transit.enabled` is `true`. | `string` | `""` | no |
+| <a name="input_port"></a> [port](#input\_port) | (Optional) The port number on which each of the cache nodes will accept connections. The default port is `6379`. | `number` | `6379` | no |
+| <a name="input_preferred_availability_zones"></a> [preferred\_availability\_zones](#input\_preferred\_availability\_zones) | (Optional) A list of AZs(Availability Zones) in which the ElastiCache Redis cluster nodes will be created. The order of the availability zones in the list is considered. The first item in the list will be the primary node. Ignored when updating. | `list(string)` | `[]` | no |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | (Optional) The version number of Redis to be used for each nodes in the ElastiCache Redis cluster. If the version is 6 or higher, the major and minor version can be set, e.g., 6.2, or the minor version can be unspecified which will use the latest version at creation time, e.g., 6.x. Otherwise, specify the full version desired, e.g., 5.0.6. The actual engine version used is returned in the attribute `redis_version_actual`. | `string` | `"6.2"` | no |
+| <a name="input_resource_group_description"></a> [resource\_group\_description](#input\_resource\_group\_description) | (Optional) The description of Resource Group. | `string` | `"Managed by Terraform."` | no |
+| <a name="input_resource_group_enabled"></a> [resource\_group\_enabled](#input\_resource\_group\_enabled) | (Optional) Whether to create Resource Group to find and group AWS resources which are created by this module. | `bool` | `true` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | (Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`. | `string` | `""` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | (Optional) A list of security group IDs to assign to the instance. | `list(string)` | `[]` | no |
+| <a name="input_sharding"></a> [sharding](#input\_sharding) | The configuration for sharding of the ElastiCache Redis cluster.<br>    (Optional) `enabled` - Whether to enable sharding (cluster mode). It enables replication across multiple shards for enhanced scalability and availability. Defaults to `false`.<br>    (Optional) `shard_size` - The number of shards in this cluster. Valid value is from `1` to `500`. Defaults to `3`.<br>    (Optional) `replicas` - The number of replicas for each shard. Valid value is from `0` to `5`. Defaults to `2`. | <pre>object({<br>    enabled    = optional(bool, false)<br>    shard_size = optional(number, 3)<br>    replicas   = optional(number, 2)<br>  })</pre> | `{}` | no |
+| <a name="input_source_backup_name"></a> [source\_backup\_name](#input\_source\_backup\_name) | (Optional) The name of a snapshot from which to restore data into the new node group. Changing the `source_backup_name` forces a new resource. | `string` | `null` | no |
+| <a name="input_source_rdb_s3_arns"></a> [source\_rdb\_s3\_arns](#input\_source\_rdb\_s3\_arns) | (Optional) A list of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The object names cannot contain any commas. | `list(string)` | `[]` | no |
+| <a name="input_subnet_group"></a> [subnet\_group](#input\_subnet\_group) | (Optional) The name of the cache subnet group to be used for the ElastiCache Redis cluster. If not provided, configured to use `default` subnet group in the default VPC. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_timeouts"></a> [timeouts](#input\_timeouts) | (Optional) How long to wait for the instance to be created/updated/deleted. | <pre>object({<br>    create = optional(string, "60m")<br>    update = optional(string, "40m")<br>    delete = optional(string, "40m")<br>  })</pre> | `{}` | no |
+| <a name="input_user_groups"></a> [user\_groups](#input\_user\_groups) | (Optional) A set of User Group IDs to associate with the ElastiCache Redis cluster. Only a maximum of one user group ID is valid. The AWS specification allows for multiple IDs, but AWS only allows a maximum size of one. | `set(string)` | `[]` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Optional) The ID of the associated VPC. You must provide the `vpc_id` when `default_security_group.enabled` is `true`. It will used to provision the default security group. | `string` | `null` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_arn"></a> [arn](#output\_arn) | The ARN of the ElastiCache Redis cluster. |
+| <a name="output_attributes"></a> [attributes](#output\_attributes) | A set of attributes that applied to the ElastiCache Redis cluster. |
+| <a name="output_auth"></a> [auth](#output\_auth) | The configuration for auth of the ElastiCache Redis cluster.<br>    `user_groups` - A set of User Group IDs to associate with the ElastiCache Redis cluster. |
+| <a name="output_backup"></a> [backup](#output\_backup) | The configuration for backup of the ElastiCache Redis cluster.<br>    `enabled` - Whether to automatically create a daily backup of a set of replicas.<br>    `window` - The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of the ElastiCache Redis cluster.<br>    `retention` - The number of days for which automated backups are retained before they are automatically deleted. |
+| <a name="output_description"></a> [description](#output\_description) | The description of the ElastiCache Redis cluster. |
+| <a name="output_encryption"></a> [encryption](#output\_encryption) | The configuration for encryption of the ElastiCache Redis cluster.<br>    `at_rest` - The configuration for at-rest encryption.<br>    `in_transit` - The configuration for in-transit encryption. |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | The connection endpoints to the ElastiCache Redis cluster.<br>    `primary` - Address of the endpoint for the primary node in the cluster, if the cluster mode is disabled.<br>    `reader` - Address of the endpoint for the reader node in the cluster, if the cluster mode is disabled.<br>    `configuration` - Address of the replication group configuration endpoint when cluster mode is enabled. |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the ElastiCache Redis cluster. |
+| <a name="output_logging"></a> [logging](#output\_logging) | The configuration for logging of the ElastiCache Redis cluster.<br>    `slow_log` - The configuration for streaming Redis Slow Log.<br>    `engine_log` - The configuration for streaming Redis Engine Log. |
+| <a name="output_maintenance"></a> [maintenance](#output\_maintenance) | The configuration for maintenance of the ElastiCache Redis cluster.<br>    `window` - The weekly time range for when maintenance on the ElastiCache Redis cluster is performed.<br>    `auto_upgrade_minor_version_enabled` - Whether automatically schedule cluster upgrade to the latest minor version, once it becomes available.<br>    `notification_sns_arn` - The ARN of an SNS topic to send ElastiCache notifications to. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the ElastiCache Redis cluster. |
+| <a name="output_network"></a> [network](#output\_network) | The configuration for network of the ElastiCache Redis cluster.<br>    `port` - The port number on each cache nodes to accept connections.<br>    `subnet_group` - The name of the cache subnet group used for.<br>    `preferred_availability_zones` - The list of AZs(Availability Zones) in which the ElastiCache Redis cluster nodes will be created. |
+| <a name="output_node_instance_type"></a> [node\_instance\_type](#output\_node\_instance\_type) | The instance type used for the ElastiCache Redis cluster. |
+| <a name="output_node_size"></a> [node\_size](#output\_node\_size) | The number of instance type used for the ElastiCache Redis cluster. |
+| <a name="output_nodes"></a> [nodes](#output\_nodes) | The list of all nodes are part of the ElastiCache Redis cluster. |
+| <a name="output_parameter_group"></a> [parameter\_group](#output\_parameter\_group) | The name of the parameter group associated with the ElastiCache Redis cluster. |
+| <a name="output_redis_version"></a> [redis\_version](#output\_redis\_version) | The version number of Redis used for the ElastiCache Redis cluster. The actual engine version used is returned in `redis_version_actual`. |
+| <a name="output_redis_version_actual"></a> [redis\_version\_actual](#output\_redis\_version\_actual) | The actual version number of Redis used for the ElastiCache Redis cluster. Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine. |
+| <a name="output_sharding"></a> [sharding](#output\_sharding) | The configuration for sharding of the ElastiCache Redis cluster. |
+| <a name="output_source"></a> [source](#output\_source) | The configuration for source backup of the ElastiCache Redis cluster to restore from.<br>    `backup_name` - The name of a snapshot from which to restore data into the new node group.<br>    `rdb_s3_arns` - The list of ARNs that identify Redis RDB snapshot files stored in Amazon S3. |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/elasticache-redis-cluster/main.tf
+++ b/modules/elasticache-redis-cluster/main.tf
@@ -1,0 +1,213 @@
+locals {
+  metadata = {
+    package = "terraform-aws-ec2"
+    version = trimspace(file("${path.module}/../../VERSION"))
+    module  = basename(path.module)
+    name    = var.name
+  }
+  module_tags = var.module_tags_enabled ? {
+    "module.terraform.io/package"   = local.metadata.package
+    "module.terraform.io/version"   = local.metadata.version
+    "module.terraform.io/name"      = local.metadata.module
+    "module.terraform.io/full-name" = "${local.metadata.package}/${local.metadata.module}"
+    "module.terraform.io/instance"  = local.metadata.name
+  } : {}
+}
+
+locals {
+  is_data_tiering_type = replace(var.node_instance_type, "/^cache\\.[a-z0-9]?d\\..*$/", "1") == "1" ? true : false
+}
+
+
+###################################################
+# Parameter Group of ElastiCache Cluster for Redis
+###################################################
+
+locals {
+  supported_families = [
+    { name = "redis2.8", prefix = "2.8" },
+    { name = "redis3.2", prefix = "3.2" },
+    { name = "redis4.0", prefix = "4.0" },
+    { name = "redis5.0", prefix = "5.0" },
+    { name = "redis6.x", prefix = "6." },
+  ]
+  family = [
+    for f in local.supported_families :
+    f.name
+    if startswith(var.redis_version, f.prefix)
+  ][0]
+
+  parameters = merge(
+    {
+      "cluster-enabled" = var.sharding.enabled ? "yes" : "no"
+    },
+    var.parameter_group.parameters
+  )
+
+  logging_destination_types = {
+    "CLOUDWATCH_LOGS"  = "cloudwatch-logs"
+    "KINESIS_FIREHOSE" = "kinesis-firehose"
+  }
+}
+
+resource "aws_elasticache_parameter_group" "this" {
+  count = var.parameter_group.enabled ? 1 : 0
+
+  name        = coalesce(var.parameter_group.name, var.name)
+  description = coalesce(var.parameter_group.description, "Customized Parameter Group for ${var.name} redis cluster. (v${var.redis_version})")
+  family      = local.family
+
+  dynamic "parameter" {
+    for_each = local.parameters
+
+    content {
+      name  = parameter.key
+      value = parameter.value
+    }
+  }
+
+  tags = merge(
+    {
+      "Name" = local.metadata.name
+    },
+    local.module_tags,
+    var.tags,
+  )
+}
+
+
+###################################################
+# ElastiCache Cluster for Redis
+###################################################
+
+# INFO: Not supported attributes
+# - `availability_zones` (Deprecated)
+# - `cluster_mode` (Deprecated)
+# - `number_cache_clusters ` (Deprecated)
+# - `replication_group_description` (Deprecated)
+# - `security_group_names` (Deprecated)
+#
+# Only need for secondary replicas
+# - `global_replication_group_id`
+resource "aws_elasticache_replication_group" "this" {
+  replication_group_id = var.name
+  description          = var.description
+
+  engine                  = "redis"
+  engine_version          = var.redis_version
+  node_type               = var.node_instance_type
+  num_cache_clusters      = !var.sharding.enabled ? var.node_size : null
+  num_node_groups         = var.sharding.enabled ? var.sharding.shard_size : null
+  replicas_per_node_group = var.sharding.enabled ? var.sharding.replicas : null
+
+
+  ## Network
+  port                        = var.port
+  subnet_group_name           = var.subnet_group
+  preferred_cache_cluster_azs = var.preferred_availability_zones
+  security_group_ids = (var.default_security_group.enabled
+    ? concat(module.security_group.*.id, var.security_groups)
+    : var.security_groups
+  )
+
+
+  ## Parameters
+  parameter_group_name = (var.parameter_group.enabled
+    ? aws_elasticache_parameter_group.this[0].name
+    : var.custom_parameter_group
+  )
+
+
+  ## Auth
+  auth_token     = length(var.password) > 0 ? var.password : null
+  user_group_ids = var.user_groups
+
+
+  ## Encryption
+  at_rest_encryption_enabled = var.encryption_at_rest.enabled
+  kms_key_id                 = var.encryption_at_rest.kms_key
+  transit_encryption_enabled = var.encryption_in_transit.enabled
+
+
+  ## Backup
+  snapshot_window           = var.backup_window
+  snapshot_retention_limit  = var.backup_enabled ? var.backup_retention : 0
+  final_snapshot_identifier = var.backup_final_snapshot_name
+
+
+  ## Source
+  snapshot_arns = var.source_rdb_s3_arns
+  snapshot_name = var.source_backup_name
+
+
+  ## Maintenance
+  maintenance_window         = var.maintenance_window
+  auto_minor_version_upgrade = var.auto_upgrade_minor_version_enabled
+  notification_topic_arn     = var.notification_sns_topic
+
+
+  ## Logging
+  dynamic "log_delivery_configuration" {
+    for_each = var.logging_slow_log.enabled ? [var.logging_slow_log] : []
+    iterator = logging
+
+    content {
+      log_type         = "slow-log"
+      log_format       = lower(logging.value.format)
+      destination_type = local.logging_destination_types[logging.value.destination_type]
+      destination      = logging.value.destination
+    }
+  }
+  dynamic "log_delivery_configuration" {
+    for_each = var.logging_engine_log.enabled ? [var.logging_engine_log] : []
+    iterator = logging
+
+    content {
+      log_type         = "engine-log"
+      log_format       = lower(logging.value.format)
+      destination_type = local.logging_destination_types[logging.value.destination_type]
+      destination      = logging.value.destination
+    }
+  }
+
+
+  ## Attributes
+  multi_az_enabled           = var.multi_az_enabled
+  automatic_failover_enabled = var.auto_failover_enabled
+  data_tiering_enabled       = local.is_data_tiering_type
+
+  apply_immediately = var.apply_immediately
+
+  timeouts {
+    create = var.timeouts.create
+    update = var.timeouts.update
+    delete = var.timeouts.delete
+  }
+
+  tags = merge(
+    {
+      "Name" = local.metadata.name
+    },
+    local.module_tags,
+    var.tags,
+  )
+
+  lifecycle {
+    precondition {
+      condition = anytrue([
+        !var.multi_az_enabled,
+        var.multi_az_enabled && var.auto_failover_enabled,
+      ])
+      error_message = "If Muti-AZ Support is enabled, `auto_failover_enabled` must also be enabled."
+    }
+    precondition {
+      condition = (length(var.password) > 0
+        ? var.encryption_in_transit.enabled
+        : true
+      )
+      error_message = "Password can be specified only if in-transit encryption is enabled."
+    }
+    ignore_changes = [
+    ]
+  }
+}

--- a/modules/elasticache-redis-cluster/outputs.tf
+++ b/modules/elasticache-redis-cluster/outputs.tf
@@ -1,0 +1,183 @@
+output "id" {
+  description = "The ID of the ElastiCache Redis cluster."
+  value       = aws_elasticache_replication_group.this.id
+}
+
+output "arn" {
+  description = "The ARN of the ElastiCache Redis cluster."
+  value       = aws_elasticache_replication_group.this.arn
+}
+
+output "name" {
+  description = "The name of the ElastiCache Redis cluster."
+  value       = var.name
+}
+
+output "description" {
+  description = "The description of the ElastiCache Redis cluster."
+  value       = aws_elasticache_replication_group.this.description
+}
+
+output "redis_version" {
+  description = "The version number of Redis used for the ElastiCache Redis cluster. The actual engine version used is returned in `redis_version_actual`."
+  value       = aws_elasticache_replication_group.this.engine_version
+}
+
+output "redis_version_actual" {
+  description = "The actual version number of Redis used for the ElastiCache Redis cluster. Because ElastiCache pulls the latest minor or patch for a version, this attribute returns the running version of the cache engine."
+  value       = aws_elasticache_replication_group.this.engine_version_actual
+}
+
+output "node_instance_type" {
+  description = "The instance type used for the ElastiCache Redis cluster."
+  value       = aws_elasticache_replication_group.this.node_type
+}
+
+output "node_size" {
+  description = "The number of instance type used for the ElastiCache Redis cluster."
+  value       = aws_elasticache_replication_group.this.num_cache_clusters
+}
+
+output "nodes" {
+  description = "The list of all nodes are part of the ElastiCache Redis cluster."
+  value       = aws_elasticache_replication_group.this.member_clusters
+}
+
+output "sharding" {
+  description = "The configuration for sharding of the ElastiCache Redis cluster."
+  value = {
+    enabled    = aws_elasticache_replication_group.this.cluster_enabled
+    shard_size = aws_elasticache_replication_group.this.num_node_groups
+    replicas   = aws_elasticache_replication_group.this.replicas_per_node_group
+  }
+}
+
+output "network" {
+  description = <<EOF
+  The configuration for network of the ElastiCache Redis cluster.
+    `port` - The port number on each cache nodes to accept connections.
+    `subnet_group` - The name of the cache subnet group used for.
+    `preferred_availability_zones` - The list of AZs(Availability Zones) in which the ElastiCache Redis cluster nodes will be created.
+  EOF
+  value = {
+    port                         = aws_elasticache_replication_group.this.port
+    vpc_id                       = var.vpc_id
+    subnet_group                 = aws_elasticache_replication_group.this.subnet_group_name
+    preferred_availability_zones = aws_elasticache_replication_group.this.preferred_cache_cluster_azs
+
+    default_security_group = one(module.security_group.*.id)
+    security_groups        = aws_elasticache_replication_group.this.security_group_ids
+  }
+}
+
+output "parameter_group" {
+  description = "The name of the parameter group associated with the ElastiCache Redis cluster."
+  value       = aws_elasticache_replication_group.this.parameter_group_name
+}
+
+output "auth" {
+  description = <<EOF
+  The configuration for auth of the ElastiCache Redis cluster.
+    `user_groups` - A set of User Group IDs to associate with the ElastiCache Redis cluster.
+  EOF
+  value = {
+    # password = aws_elasticache_replication_group.this.auth_token
+    user_groups = aws_elasticache_replication_group.this.user_group_ids
+  }
+}
+
+output "encryption" {
+  description = <<EOF
+  The configuration for encryption of the ElastiCache Redis cluster.
+    `at_rest` - The configuration for at-rest encryption.
+    `in_transit` - The configuration for in-transit encryption.
+  EOF
+  value = {
+    at_rest = {
+      enabled = aws_elasticache_replication_group.this.at_rest_encryption_enabled
+      kms_key = aws_elasticache_replication_group.this.kms_key_id
+    }
+    in_transit = {
+      enabled = aws_elasticache_replication_group.this.transit_encryption_enabled
+    }
+  }
+}
+
+output "backup" {
+  description = <<EOF
+  The configuration for backup of the ElastiCache Redis cluster.
+    `enabled` - Whether to automatically create a daily backup of a set of replicas.
+    `window` - The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of the ElastiCache Redis cluster.
+    `retention` - The number of days for which automated backups are retained before they are automatically deleted.
+  EOF
+  value = {
+    enabled   = aws_elasticache_replication_group.this.snapshot_retention_limit != 0
+    window    = aws_elasticache_replication_group.this.snapshot_window
+    retention = aws_elasticache_replication_group.this.snapshot_retention_limit
+
+    final_snapshot_name = aws_elasticache_replication_group.this.final_snapshot_identifier
+  }
+}
+
+output "source" {
+  description = <<EOF
+  The configuration for source backup of the ElastiCache Redis cluster to restore from.
+    `backup_name` - The name of a snapshot from which to restore data into the new node group.
+    `rdb_s3_arns` - The list of ARNs that identify Redis RDB snapshot files stored in Amazon S3.
+  EOF
+  value = {
+    backup_name = aws_elasticache_replication_group.this.snapshot_name
+    rdb_s3_arns = aws_elasticache_replication_group.this.snapshot_arns
+  }
+}
+
+output "maintenance" {
+  description = <<EOF
+  The configuration for maintenance of the ElastiCache Redis cluster.
+    `window` - The weekly time range for when maintenance on the ElastiCache Redis cluster is performed.
+    `auto_upgrade_minor_version_enabled` - Whether automatically schedule cluster upgrade to the latest minor version, once it becomes available.
+    `notification_sns_arn` - The ARN of an SNS topic to send ElastiCache notifications to.
+  EOF
+  value = {
+    window                             = aws_elasticache_replication_group.this.maintenance_window
+    auto_upgrade_minor_version_enabled = aws_elasticache_replication_group.this.auto_minor_version_upgrade
+    notification_sns_topic             = aws_elasticache_replication_group.this.notification_topic_arn
+  }
+}
+
+output "logging" {
+  description = <<EOF
+  The configuration for logging of the ElastiCache Redis cluster.
+    `slow_log` - The configuration for streaming Redis Slow Log.
+    `engine_log` - The configuration for streaming Redis Engine Log.
+  EOF
+  value = {
+    slow_log   = var.logging_slow_log
+    engine_log = var.logging_engine_log
+  }
+}
+
+output "attributes" {
+  description = "A set of attributes that applied to the ElastiCache Redis cluster."
+  value = {
+    apply_immediately     = aws_elasticache_replication_group.this.apply_immediately
+    auto_failover_enabled = aws_elasticache_replication_group.this.automatic_failover_enabled
+    muti_az_enabled       = aws_elasticache_replication_group.this.multi_az_enabled
+
+    data_tiering_enabled = aws_elasticache_replication_group.this.data_tiering_enabled
+  }
+}
+
+output "endpoints" {
+  description = <<EOF
+  The connection endpoints to the ElastiCache Redis cluster.
+    `primary` - Address of the endpoint for the primary node in the cluster, if the cluster mode is disabled.
+    `reader` - Address of the endpoint for the reader node in the cluster, if the cluster mode is disabled.
+    `configuration` - Address of the replication group configuration endpoint when cluster mode is enabled.
+  EOF
+  value = {
+    primary       = aws_elasticache_replication_group.this.primary_endpoint_address
+    reader        = aws_elasticache_replication_group.this.reader_endpoint_address
+    configuration = aws_elasticache_replication_group.this.configuration_endpoint_address
+  }
+}

--- a/modules/elasticache-redis-cluster/resource-group.tf
+++ b/modules/elasticache-redis-cluster/resource-group.tf
@@ -1,0 +1,31 @@
+locals {
+  resource_group_name = (var.resource_group_name != ""
+    ? var.resource_group_name
+    : join(".", [
+      local.metadata.package,
+      local.metadata.module,
+      replace(local.metadata.name, "/[^a-zA-Z0-9_\\.-]/", "-"),
+    ])
+  )
+}
+
+
+module "resource_group" {
+  source  = "tedilabs/misc/aws//modules/resource-group"
+  version = "~> 0.10.0"
+
+  count = (var.resource_group_enabled && var.module_tags_enabled) ? 1 : 0
+
+  name        = local.resource_group_name
+  description = var.resource_group_description
+
+  query = {
+    resource_tags = local.module_tags
+  }
+
+  module_tags_enabled = false
+  tags = merge(
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/elasticache-redis-cluster/security-group.tf
+++ b/modules/elasticache-redis-cluster/security-group.tf
@@ -1,0 +1,32 @@
+###################################################
+# Security Group
+###################################################
+
+module "security_group" {
+  source  = "tedilabs/network/aws//modules/security-group"
+  version = "~> 0.26.0"
+
+  count = var.default_security_group.enabled ? 1 : 0
+
+  name        = coalesce(var.default_security_group.name, local.metadata.name)
+  description = var.default_security_group.description
+  vpc_id      = var.vpc_id
+
+  ingress_rules = [
+    for i, rule in var.default_security_group.ingress_rules :
+    merge(rule, {
+      id        = try(rule.id, "redis-${i}")
+      protocol  = "tcp"
+      from_port = var.port
+      to_port   = var.port
+    })
+  ]
+
+  resource_group_enabled = false
+  module_tags_enabled    = false
+
+  tags = merge(
+    local.module_tags,
+    var.tags,
+  )
+}

--- a/modules/elasticache-redis-cluster/variables.tf
+++ b/modules/elasticache-redis-cluster/variables.tf
@@ -1,0 +1,399 @@
+variable "name" {
+  description = "(Required) The name of the ElastiCache Redis cluster. This parameter is stored as a lowercase string."
+  type        = string
+  nullable    = false
+}
+
+variable "description" {
+  description = "(Optional) The description of the ElastiCache Redis cluster."
+  type        = string
+  default     = "Managed by Terraform."
+  nullable    = false
+}
+
+variable "redis_version" {
+  description = "(Optional) The version number of Redis to be used for each nodes in the ElastiCache Redis cluster. If the version is 6 or higher, the major and minor version can be set, e.g., 6.2, or the minor version can be unspecified which will use the latest version at creation time, e.g., 6.x. Otherwise, specify the full version desired, e.g., 5.0.6. The actual engine version used is returned in the attribute `redis_version_actual`."
+  type        = string
+  default     = "6.2"
+  nullable    = false
+}
+
+# INFO: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CacheNodes.SupportedTypes.html
+variable "node_instance_type" {
+  description = "(Required) The instance type to be deployed for the ElastiCache Redis cluster."
+  type        = string
+  nullable    = false
+}
+
+variable "node_size" {
+  description = "(Optional) The number of cache nodes (primary and replicas) for this ElastiCache Redis cluster will have. If Multi-AZ is enabled, this value must be at least 2. Updates will occur before other modifications. Defaults to `1`."
+  type        = number
+  default     = 1
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      var.node_size >= 1
+    ])
+    error_message = "`node_size` should be greater than `0`."
+  }
+}
+
+variable "sharding" {
+  description = <<EOF
+  The configuration for sharding of the ElastiCache Redis cluster.
+    (Optional) `enabled` - Whether to enable sharding (cluster mode). It enables replication across multiple shards for enhanced scalability and availability. Defaults to `false`.
+    (Optional) `shard_size` - The number of shards in this cluster. Valid value is from `1` to `500`. Defaults to `3`.
+    (Optional) `replicas` - The number of replicas for each shard. Valid value is from `0` to `5`. Defaults to `2`.
+  EOF
+  type = object({
+    enabled    = optional(bool, false)
+    shard_size = optional(number, 3)
+    replicas   = optional(number, 2)
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition = alltrue([
+      var.sharding.shard_size >= 1,
+      var.sharding.shard_size <= 500,
+    ])
+    error_message = "The number of shards should be between `1` and `500`."
+  }
+
+  validation {
+    condition = alltrue([
+      var.sharding.replicas >= 0,
+      var.sharding.replicas <= 5,
+    ])
+    error_message = "The number of replicas for each shard should be between `0` and `5`."
+  }
+}
+
+variable "port" {
+  description = "(Optional) The port number on which each of the cache nodes will accept connections. The default port is `6379`."
+  type        = number
+  default     = 6379
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      var.port >= 1,
+      var.port <= 65535
+    ])
+    error_message = "Valid values range for `port` from 1 through 65535."
+  }
+}
+
+variable "vpc_id" {
+  description = "(Optional) The ID of the associated VPC. You must provide the `vpc_id` when `default_security_group.enabled` is `true`. It will used to provision the default security group."
+  type        = string
+  default     = null
+}
+
+variable "subnet_group" {
+  description = "(Optional) The name of the cache subnet group to be used for the ElastiCache Redis cluster. If not provided, configured to use `default` subnet group in the default VPC."
+  type        = string
+  default     = null
+}
+
+variable "preferred_availability_zones" {
+  description = "(Optional) A list of AZs(Availability Zones) in which the ElastiCache Redis cluster nodes will be created. The order of the availability zones in the list is considered. The first item in the list will be the primary node. Ignored when updating."
+  type        = list(string)
+  default     = []
+}
+
+variable "default_security_group" {
+  description = <<EOF
+  (Optional) The configuration of the default security group for the ElastiCache Redis cluster. `default_security_group` block as defined below.
+    (Optional) `enabled` - Whether to use the default security group. Defaults to `true`.
+    (Optional) `name` - The name of the default security group. If not provided, the cluster name is used for the name of security group.
+    (Optional) `description` - The description of the default security group.
+    (Optional) `ingress_rules` - A list of ingress rules in a security group. You don't need to specify `protocol`, `from_port`, `to_port`. Just specify source information. Defauls to `[{ cidr_blocks = "0.0.0.0/0" }]`.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, null)
+    description = optional(string, "Managed by Terraform.")
+    ingress_rules = optional(any, [{
+      cidr_blocks = ["0.0.0.0/0"]
+    }])
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "security_groups" {
+  description = "(Optional) A list of security group IDs to assign to the instance."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "parameter_group" {
+  description = <<EOF
+  The configuration for parameter group of the ElastiCache Redis cluster.
+    (Optional) `enabled` - Whether to enable managed parameter group by this module.
+    (Optional) `name` - The name of the managed parameter group. If not provided, the name is configured with the cluster name.
+    (Optional) `description` - The description of the managed parameter group.
+    (Optional) `parameters` - The key/value set for Redis parameters of ElastiCache Redis cluster. Each key is the name of the redis parameter. Each value is the value of the redis parameter.
+  EOF
+  type = object({
+    enabled     = optional(bool, true)
+    name        = optional(string, "")
+    description = optional(string, "")
+    parameters  = optional(map(string), {})
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "custom_parameter_group" {
+  description = "(Optional) The name of the parameter group to associate with the ElastiCache Redis cluster. If this argument is omitted, the default cache parameter group for the specified engine is used. To enable `cluster mode` (sharding), use a parameter group that has the parameter `cluster-enabled` set to `true`."
+  type        = string
+  default     = null
+}
+
+variable "password" {
+  description = "(Optional) Password used to access a password protected ElastiCache Redis cluster. Can be specified only if `encryption_in_transit.enabled` is `true`."
+  type        = string
+  default     = ""
+  nullable    = false
+  sensitive   = true
+
+  validation {
+    condition = anytrue([
+      length(var.password) == 0,
+      length(var.password) >= 16 && length(var.password) <= 128
+    ])
+    error_message = "`password` must contain from 16 to 128 alphanumeric characters or symbols (excluding @, \", and /)."
+  }
+}
+
+variable "user_groups" {
+  description = "(Optional) A set of User Group IDs to associate with the ElastiCache Redis cluster. Only a maximum of one user group ID is valid. The AWS specification allows for multiple IDs, but AWS only allows a maximum size of one."
+  type        = set(string)
+  default     = []
+  nullable    = false
+}
+
+variable "encryption_at_rest" {
+  description = <<EOF
+  The configuration for at-rest encryption of the ElastiCache Redis cluster.
+    (Optional) `enabled` - Whether to enable at-rest encryption. Defaults to `false`.
+    (Optional) `kms_key` - The ARN of the key to use for at-rest encryption. If not supplied, uses service managed encryption key. Can be specified only if `encryption_at_rest.enabled` is `true`.
+  EOF
+  type = object({
+    enabled = optional(bool, false)
+    kms_key = optional(string, null)
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "encryption_in_transit" {
+  description = <<EOF
+  The configuration for in-transit encryption of the ElastiCache Redis cluster.
+    (Optional) `enabled` - Whether to enable in-transit encryption. Defaults to `false`.
+  EOF
+  type = object({
+    enabled = optional(bool, false)
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "backup_enabled" {
+  description = "(Optional) Whether to automatically create a daily backup of a set of replicas. Defaults to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "backup_window" {
+  description = "(Optional) The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of the ElastiCache Redis cluster. The minimum snapshot window is a 60 minute period. Example: 05:00-09:00. Defaults to `16:00-17:00`."
+  type        = string
+  default     = "16:00-17:00"
+  nullable    = false
+}
+
+variable "backup_retention" {
+  description = "(Optional) The number of days for which automated backups are retained before they are automatically deleted. Valid value is between `1` and `35`. Defaults to 1."
+  type        = number
+  default     = 1
+  nullable    = false
+
+  validation {
+    condition = alltrue([
+      var.backup_retention >= 1,
+      var.backup_retention <= 35,
+    ])
+    error_message = "The value of `backup_retention` must be between 1 and 35."
+  }
+}
+
+variable "backup_final_snapshot_name" {
+  description = "(Optional) The name of your final node group (shard) snapshot. ElastiCache creates the snapshot from the primary node in the cluster. If omitted, no final snapshot will be made."
+  type        = string
+  default     = null
+}
+
+variable "source_backup_name" {
+  description = "(Optional) The name of a snapshot from which to restore data into the new node group. Changing the `source_backup_name` forces a new resource."
+  type        = string
+  default     = null
+}
+
+variable "source_rdb_s3_arns" {
+  description = "(Optional) A list of ARNs that identify Redis RDB snapshot files stored in Amazon S3. The object names cannot contain any commas."
+  type        = list(string)
+  default     = []
+  nullable    = false
+}
+
+variable "maintenance_window" {
+  description = "(Optional) The weekly time range for when maintenance on the ElastiCache Redis cluster is performed. The format is `ddd:hh24:mi-ddd:hh24:mi` (24H Clock UTC). The minimum maintenance window is a 60 minute period. Example: `sun:05:00-sun:09:00`. Defaults to `fri:18:00-fri:20:00`."
+  type        = string
+  default     = "fri:18:00-fri:20:00"
+  nullable    = false
+}
+
+variable "auto_upgrade_minor_version_enabled" {
+  description = "(Optional) Whether automatically schedule cluster upgrade to the latest minor version, once it becomes available. Cluster upgrade will only be scheduled during the maintenance window. Defaults to `true`. Only supported if the redis version is 6 or higher."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "notification_sns_topic" {
+  description = "(Optional) The ARN of an SNS topic to send ElastiCache notifications to."
+  type        = string
+  default     = null
+}
+
+variable "logging_slow_log" {
+  description = <<EOF
+  The configuration for streaming Redis Slow Log of the ElastiCache Redis cluster.
+    (Optional) `enabled` - Whether to enable streaming Redis Slow Log. Defaults to `false`.
+    (Optional) `format` - The format of Redis Slow Log. Valid values are `JSON` or `TEXT`. Defaults to `JSON`.
+    (Optional) `destination_type` - The destination type for streaming Redis Slow Log. For CloudWatch Logs use `CLOUDWATCH_LOGS` or for Kinesis Data Firehose use `KINESIS_FIREHOSE`. Defaults to `CLOUDWATCH_LOGS`.
+    (Optional) `destination` - The name of either the CloudWatch Logs LogGroup or Kinesis Data Firehose resource.
+  EOF
+  type = object({
+    enabled          = optional(bool, false)
+    format           = optional(string, "JSON")
+    destination_type = optional(string, "CLOUDWATCH_LOGS")
+    destination      = optional(string, null)
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["TEXT", "JSON"], var.logging_slow_log.format)
+    error_message = "Valid value for `format` is `TEXT` or `JSON`."
+  }
+  validation {
+    condition     = contains(["CLOUDWATCH_LOGS", "KINESIS_FIREHOSE"], var.logging_slow_log.destination_type)
+    error_message = "Valid value for `destination_type` s `CLOUDWATCH_LOGS` or `KINESIS_FIREHOSE`."
+  }
+}
+
+variable "logging_engine_log" {
+  description = <<EOF
+  The configuration for streaming Redis Engine Log of the ElastiCache Redis cluster.
+    (Optional) `enabled` - Whether to enable streaming Redis Engine Log. Defaults to `false`.
+    (Optional) `format` - The format of Redis Engine Log. Valid values are `JSON` or `TEXT`. Defaults to `JSON`.
+    (Optional) `destination_type` - The destination type for streaming Redis Engine Log. For CloudWatch Logs use `CLOUDWATCH_LOGS` or for Kinesis Data Firehose use `KINESIS_FIREHOSE`. Defaults to `CLOUDWATCH_LOGS`.
+    (Optional) `destination` - The name of either the CloudWatch Logs LogGroup or Kinesis Data Firehose resource.
+  EOF
+  type = object({
+    enabled          = optional(bool, false)
+    format           = optional(string, "JSON")
+    destination_type = optional(string, "CLOUDWATCH_LOGS")
+    destination      = optional(string, null)
+  })
+  default  = {}
+  nullable = false
+
+  validation {
+    condition     = contains(["TEXT", "JSON"], var.logging_engine_log.format)
+    error_message = "Valid value for `format` is `TEXT` or `JSON`."
+  }
+  validation {
+    condition     = contains(["CLOUDWATCH_LOGS", "KINESIS_FIREHOSE"], var.logging_engine_log.destination_type)
+    error_message = "Valid value for `destination_type` s `CLOUDWATCH_LOGS` or `KINESIS_FIREHOSE`."
+  }
+}
+
+variable "multi_az_enabled" {
+  description = "(Optional) Whether to enable Multi-AZ Support for the ElastiCache Redis cluster. If true, `auto_failover_enabled` must also be enabled. Defaults to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "auto_failover_enabled" {
+  description = "(Optional) Whether a read-only replica will be automatically promoted to read/write primary if the existing primary fails. If enabled, `node_size` must be greater than 1. Must be enabled for Redis (cluster mode enabled) cluster. Defaults to `false`. ElastiCache Auto Failover provides enhanced high availability through automatic failover to a read replica in case of a primary node failover."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "apply_immediately" {
+  description = "(Optional) Whether any modifications are applied immediately, or during the next maintenance window. Default to `false`."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "timeouts" {
+  description = "(Optional) How long to wait for the instance to be created/updated/deleted."
+  type = object({
+    create = optional(string, "60m")
+    update = optional(string, "40m")
+    delete = optional(string, "40m")
+  })
+  default  = {}
+  nullable = false
+}
+
+variable "tags" {
+  description = "(Optional) A map of tags to add to all resources."
+  type        = map(string)
+  default     = {}
+  nullable    = false
+}
+
+variable "module_tags_enabled" {
+  description = "(Optional) Whether to create AWS Resource Tags for the module informations."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+
+###################################################
+# Resource Group
+###################################################
+
+variable "resource_group_enabled" {
+  description = "(Optional) Whether to create Resource Group to find and group AWS resources which are created by this module."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "resource_group_name" {
+  description = "(Optional) The name of Resource Group. A Resource Group name can have a maximum of 127 characters, including letters, numbers, hyphens, dots, and underscores. The name cannot start with `AWS` or `aws`."
+  type        = string
+  default     = ""
+  nullable    = false
+}
+
+variable "resource_group_description" {
+  description = "(Optional) The description of Resource Group."
+  type        = string
+  default     = "Managed by Terraform."
+  nullable    = false
+}

--- a/modules/elasticache-redis-cluster/versions.tf
+++ b/modules/elasticache-redis-cluster/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.3"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.30"
+    }
+  }
+}


### PR DESCRIPTION
### Background

- Add `elasticache-redis-cluster` module to support ElastiCache Redis Cluster.