### PR TITLE
chore(deps): align tedilabs child module version constraints with latest releases

### DIFF
--- a/modules/elasticache-redis-cluster/README.md
+++ b/modules/elasticache-redis-cluster/README.md
@@ -27,7 +27,7 @@ This module creates following resources.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_resource_group"></a> [resource\_group](#module\_resource\_group) | tedilabs/misc/aws//modules/resource-group | ~> 0.12.0 |
-| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | tedilabs/network/aws//modules/security-group | ~> 1.0.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | tedilabs/network/aws//modules/security-group | ~> 1.2.0 |
 
 ## Resources
 

--- a/modules/elasticache-redis-cluster/security-group.tf
+++ b/modules/elasticache-redis-cluster/security-group.tf
@@ -4,7 +4,7 @@
 
 module "security_group" {
   source  = "tedilabs/network/aws//modules/security-group"
-  version = "~> 1.0.0"
+  version = "~> 1.2.0"
 
   count = var.default_security_group.enabled ? 1 : 0
 


### PR DESCRIPTION
## What & why

The `version` constraints this repo declares for sibling `tedilabs/*` child modules had drifted well behind those modules' latest releases. This realigns them to the house convention of a minor floor (`~> MAJOR.MINOR.0`) matching the newest published release, so a fresh `terraform init` resolves the current module code instead of an old branch of it.

Scope is intentionally narrow: constraint values only. No functional HCL changes.

## Changed constraints

### Active module blocks

| Child module | Path | Before | After | Latest release |
|---|---|---|---|---|
| `tedilabs/network/aws//modules/security-group` | `modules/elasticache-redis-cluster/security-group.tf` | `~> 1.0.0` | `~> 1.2.0` | `v1.2.3` |

There are no commented-out registry references in `examples/` in this repo, so there is no second table.

## Interface changes between the old and new versions

### `tedilabs/network/aws//modules/security-group` : v1.0.2 -> v1.2.3

Compare: https://github.com/tedilabs/terraform-aws-network/compare/v1.0.2...v1.2.3

**Verdict: BACKWARD_COMPATIBLE — no calling-code changes required, and none were made.**

- **Added variables:** none.
- **Removed variables:** none.
- **Renamed/retyped variables:** one, and it is a pure relaxation — `from_port` and `to_port` inside the `ingress_rules` / `egress_rules` element objects went from required `number` to `optional(number)`.
- **Output changes:** none. `outputs.tf` is unchanged across the range.
- **Provider / terraform version floor:** unchanged. Both tags declare `required_version = ">= 1.12"` and `aws >= 6.12`.

Our call site in `modules/elasticache-redis-cluster/security-group.tf` always sets `protocol`, `from_port` and `to_port` explicitly when building `ingress_rules`, so the relaxation is invisible to us.

**RAM share operational note — does not apply to this repo.** Between v1.0.2 and v1.2.3 the module's internal `ram-share.tf` changed: the nested `tedilabs/organization/aws//modules/ram-share` went `~> 0.4.0` -> `~> 0.5.0`, its `resources` argument went from a list to a map keyed by `var.name`, and the generated share name is now sanitised with `replace(var.name, "/[^a-zA-Z0-9_\\.-]/", "-")`. That only produces a plan diff for callers that set `shares`. I grepped this repo: no call site passes `shares` (it defaults to `[]`, so `module.share` has zero instances). Expected plan impact here is empty.

## Verification

- `terraform fmt -recursive -check .` — passes.
- `modules/elasticache-redis-cluster`: `terraform init -backend=false` + `terraform validate` — **Success, the configuration is valid.** `init` resolved the new constraint to `tedilabs/network/aws` **v1.2.3** (confirmed in `.terraform/modules/modules.json`), which is the real proof both that the constraint resolves and that the interface still matches our call.
- `.terraform/` and `.terraform.lock.hcl` were removed after validating; `git status` was clean apart from the single intended file before committing.

Honest caveats:

- The `hashicorp/aws` provider release that `init` selects by default in my environment (v6.58.0) has a binary that fails the go-plugin handshake locally, so `terraform validate` could not run against it. I validated against `hashicorp/aws` v6.33.0 instead, which satisfies every constraint in the graph (`>= 6.0.0, >= 6.12.0, >= 6.33.0`). The module resolution and schema check are therefore genuine, just not against the newest provider patch.
- No `terraform plan` or `apply` was run, so the "empty plan" claims above are reasoned from the diff of the child module, not observed against real state.

## Supersedes

- **#46** — `chore(deps): update tedilabs/network/aws requirement from ~> 0.26.0 to ~> 1.2.2 in /modules/elasticache-redis-cluster`. Same constraint, same file. This PR supersedes it because dependabot pins the exact patch (`~> 1.2.2`) rather than the house minor-floor convention (`~> 1.2.0`). Note also that #46's title claims a starting point of `~> 0.26.0`, but the file on `main` actually reads `~> 1.0.0` — the dependabot branch is stale. I have **not** closed it; please close it manually when this merges.

Not superseded (unrelated): #42 and #41 are GitHub Actions bumps, and #33 is a `tedilabs/misc/aws` bump in `/modules/elasticache-redis-user-group`, which was not in scope for this sweep.

## Known gap

The work order for this sweep also listed `modules/rds-aurora-postgresql-cluster/security-group.tf` for the same bump. **That module does not exist on `main`** — it lives only on the unmerged `rds-aurora-postgresql-cluster` branch, which is where the order's line numbers came from. This PR branches from `origin/main` and therefore cannot touch it. Whoever lands that branch should apply `~> 1.2.0` there as part of it.
