### PR TITLE
fix(examples): correct silently-ignored module arguments and refresh the README usage block

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,30 +34,36 @@ module "cluster" {
   name        = "example-redis-full"
   description = "Managed by Terraform."
 
-  redis_version      = "6.2"
+  engine = {
+    type    = "redis"
+    version = "7.1"
+  }
   node_instance_type = "cache.t4g.micro"
   # node_size          = 1
-  sharding = {
-    enabled    = true
+  cluster_mode = {
+    state      = "ENABLED"
     shard_size = 3
     replicas   = 2
   }
 
 
   ## Network
+  ip_address_type              = "IPv4"
+  discovery_ip_address_type    = "IPv4"
   port                         = 6379
-  vpc_id                       = null
-  subnet_group                 = null
+  vpc_id                       = "vpc-0123456789abcdef0"
+  subnet_group                 = "example-redis-subnet-group"
   preferred_availability_zones = []
 
   default_security_group = {
-    eanbled     = true
+    enabled     = true
     name        = "example-redis-full-default-sg"
     description = "Managed by Terraform."
 
     ingress_rules = [
       {
-        cidr_blocks = ["0.0.0.0/0"]
+        id         = "all"
+        ipv4_cidrs = ["0.0.0.0/0"]
       }
     ]
   }
@@ -65,7 +71,7 @@ module "cluster" {
 
 
   ## Parameters
-  parameter_group = {
+  default_parameter_group = {
     enabled     = true
     name        = "example-redis-full-parameter-group"
     description = "Managed by Terraform."
@@ -76,12 +82,13 @@ module "cluster" {
       "rename-commands"          = "KEYS BLOCKED"
     }
   }
-  custom_parameter_group = null
+  parameter_group = null
 
 
   ## Auth
-  password    = sensitive("helloworld!#!!1234")
-  user_groups = []
+  password                 = sensitive("helloworld!#!!1234")
+  password_update_strategy = "ROTATE"
+  user_groups              = []
 
 
   ## Encryption
@@ -91,25 +98,32 @@ module "cluster" {
   }
   encryption_in_transit = {
     enabled = true
+    mode    = "required"
   }
 
 
   ## Backup
-  backup_enabled             = true
-  backup_window              = "16:00-17:00"
-  backup_retention           = 1
-  backup_final_snapshot_name = "example-redis-full-final"
+  backup = {
+    enabled             = true
+    window              = "16:00-17:00"
+    retention           = 1
+    final_snapshot_name = "example-redis-full-final"
+  }
 
 
-  ## Source
-  source_backup_name = null
-  source_rdb_s3_arns = null
+  ## Restore
+  restore = {
+    backup_name = null
+    rdb_s3_arns = null
+  }
 
 
   ## Maintenance
-  maintenance_window                 = "fri:18:00-fri:20:00"
-  auto_upgrade_minor_version_enabled = true
-  notification_sns_topic             = null
+  maintenance = {
+    window                             = "fri:18:00-fri:20:00"
+    auto_upgrade_minor_version_enabled = true
+    notification_sns_topic             = null
+  }
 
 
   ## Logging
@@ -117,15 +131,19 @@ module "cluster" {
     enabled = false
     format  = "JSON"
 
-    destination_type = "CLOUDWATCH_LOGS"
-    destination      = null
+    destination = {
+      type = "CLOUDWATCH_LOGS"
+      name = null
+    }
   }
   logging_engine_log = {
     enabled = false
     format  = "JSON"
 
-    destination_type = "CLOUDWATCH_LOGS"
-    destination      = null
+    destination = {
+      type = "CLOUDWATCH_LOGS"
+      name = null
+    }
   }
 
 

--- a/examples/elasticache-redis-full/main.tf
+++ b/examples/elasticache-redis-full/main.tf
@@ -76,7 +76,7 @@ module "cluster" {
   preferred_availability_zones = []
 
   default_security_group = {
-    eanbled     = true
+    enabled     = true
     name        = "example-redis-full-default-sg"
     description = "Managed by Terraform."
 
@@ -151,15 +151,19 @@ module "cluster" {
     enabled = false
     format  = "JSON"
 
-    destination_type = "CLOUDWATCH_LOGS"
-    destination      = null
+    destination = {
+      type = "CLOUDWATCH_LOGS"
+      name = null
+    }
   }
   logging_engine_log = {
     enabled = false
     format  = "JSON"
 
-    destination_type = "CLOUDWATCH_LOGS"
-    destination      = null
+    destination = {
+      type = "CLOUDWATCH_LOGS"
+      name = null
+    }
   }
 
 

--- a/examples/elasticache-redis-with-users/main.tf
+++ b/examples/elasticache-redis-with-users/main.tf
@@ -89,7 +89,7 @@ module "user_group" {
   engine = "redis"
 
   name  = "example"
-  users = [module.user["example-admin"].id]
+  users = [module.user["admin"].id]
 
   tags = {
     "project" = "terraform-aws-db-examples"


### PR DESCRIPTION
## What & why

Sweep to make every `modules/*` and `examples/*` directory pass `terraform fmt -check`,
`terraform init -backend=false`, and `terraform validate`, and to make the example HCL — in
`examples/` and in the README usage block — actually correct against the current module interfaces.
All three commands already passed everywhere on `main`, so nothing here unblocks CI. What this fixes
is a class of problem `terraform validate` cannot catch: Terraform's object type conversion silently
**drops** attributes that are not declared in a variable's `object(...)` type constraint, so a
misspelled or renamed nested attribute in a module call validates cleanly and then does nothing.
Three such latent defects were found, plus a README usage block still written against the pre-0.2
interface.

## Validation matrix

`terraform fmt -check -recursive .` / `terraform init -backend=false` / `terraform validate` per
directory. `terraform fmt -recursive -check .` at the repo root passes before and after.

| Directory | fmt (before) | init (before) | validate (before) | fmt (after) | init (after) | validate (after) |
| --- | --- | --- | --- | --- | --- | --- |
| `modules/elasticache-redis-cluster` | pass | pass | pass | pass | pass | pass |
| `modules/elasticache-redis-user` | pass | pass | pass | pass | pass | pass |
| `modules/elasticache-redis-user-group` | pass | pass | pass | pass | pass | pass |
| `examples/elasticache-redis-full` | pass | pass | pass | pass | pass | pass |
| `examples/elasticache-redis-muti-az` | pass | pass | pass | pass | pass | pass |
| `examples/elasticache-redis-single` | pass | pass | pass | pass | pass | pass |
| `examples/elasticache-redis-with-users` | pass | pass | pass | pass | pass | pass |

README usage block (extracted into a scratch root outside the repo, `source` repointed at
`modules/elasticache-redis-cluster` by relative path, with a `versions.tf` added): **init and
validate failed before** (`sharding`, `redis_version`, `custom_parameter_group`,
`backup_*`, `source_*`, `maintenance_window`, `auto_upgrade_minor_version_enabled`,
`notification_sns_topic` are not variables of the module any more), **pass after**.

## Changes

### 1. Silently-dropped attribute — misspelling (`examples/elasticache-redis-full`)

```diff
   default_security_group = {
-    eanbled     = true
+    enabled     = true
```

`default_security_group` is `object({ enabled = optional(bool, true), ... })`
(`modules/elasticache-redis-cluster/variables.tf`). `eanbled` is not a declared attribute, so it was
dropped during type conversion and the example was never actually setting anything. It happened to
be harmless because `enabled` defaults to `true`, but the example did not demonstrate what it reads
as demonstrating.

### 2. Silently-dropped attributes — nested object refactor (`examples/elasticache-redis-full`)

```diff
   logging_slow_log = {
     enabled = false
     format  = "JSON"
-
-    destination_type = "CLOUDWATCH_LOGS"
-    destination      = null
+
+    destination = {
+      type = "CLOUDWATCH_LOGS"
+      name = null
+    }
   }
```

Same change for `logging_engine_log`. Per `variables.tf`, both variables are now
`object({ enabled, format, destination = optional(object({ type, name })) })` — there is no
`destination_type` attribute, and `destination` is an object, not a string. The old flat keys were
dropped silently.

### 3. Stale `for_each` key reference (`examples/elasticache-redis-with-users`)

```diff
   name  = "example"
-  users = [module.user["example-admin"].id]
+  users = [module.user["admin"].id]
```

Commit d91285c changed `module.user`'s `for_each` key from `user.id` (values `example-default`,
`example-admin`) to `user.name` (values `default`, `admin`) and dropped the `id` field from the
`locals.users` entries, but left this reference on the old key. `terraform validate` does not resolve
module instance keys, so it stayed green; `terraform plan` would have failed with an invalid index.
Verified with `terraform console` in that directory:

```
> keys({for user in local.users : user.name => user})
[
  "admin",
  "default",
]
```

### 4. README usage block rewritten against the current interface

The block in `README.md` was written for the pre-0.2 interface. Renames applied, each checked against
`modules/elasticache-redis-cluster/variables.tf`:

| Before | After | Note |
| --- | --- | --- |
| `redis_version = "6.2"` | `engine = { type = "redis", version = "7.1" }` | `redis_version` no longer exists; `engine` is a required object |
| `sharding = { enabled = true, ... }` | `cluster_mode = { state = "ENABLED", ... }` | variable renamed; `enabled` bool became a `state` enum (`ENABLED`/`DISABLED`/`COMPATIABLE`) |
| `parameter_group = { enabled, name, ... }` | `default_parameter_group = { ... }` | the managed-parameter-group object moved to `default_parameter_group` |
| `custom_parameter_group = null` | `parameter_group = null` | `parameter_group` is now a plain `string` naming an externally-managed group |
| `backup_enabled` / `backup_window` / `backup_retention` / `backup_final_snapshot_name` | `backup = { enabled, window, retention, final_snapshot_name }` | collapsed into one object |
| `source_backup_name` / `source_rdb_s3_arns` | `restore = { backup_name, rdb_s3_arns }` | collapsed and renamed |
| `maintenance_window` / `auto_upgrade_minor_version_enabled` / `notification_sns_topic` | `maintenance = { window, auto_upgrade_minor_version_enabled, notification_sns_topic }` | collapsed into one object |
| `ingress_rules = [{ cidr_blocks = [...] }]` | `ingress_rules = [{ id = "all", ipv4_cidrs = [...] }]` | `cidr_blocks` renamed to `ipv4_cidrs`; `id` is now a required attribute of each rule |
| `logging_*.destination_type` + `destination` | `logging_*.destination = { type, name }` | same nested-object change as (2) |
| `eanbled` (in `default_security_group`) | `enabled` | same typo as (1) |
| — | `ip_address_type`, `discovery_ip_address_type`, `password_update_strategy`, `encryption_in_transit.mode` | new variables; included because the block's style is to show the full surface |
| `vpc_id = null`, `subnet_group = null` | placeholder id / name strings | both are `nullable = false` and `subnet_group` is required, so `null` could never work |

The `version = "~> 0.2.0"` pin was left as-is: the repo's latest tag is `v0.2.0`, so the pin is
current.

## Still failing

Nothing. Every `modules/*` and `examples/*` directory passes fmt, init and validate on this branch,
as it did on `main`.

## Verification

- Ran `terraform fmt -check -recursive .`, `terraform init -backend=false`, `terraform validate` in
  each of the 3 module and 4 example directories, before and after the change, cleaning
  `.terraform`/`.terraform.lock.hcl` between directories. Terraform v1.15.6, `hashicorp/aws` v6.58.0.
- Proved the README block by extracting it into a scratch root outside the repo, repointing `source`
  at `modules/elasticache-redis-cluster` by relative path, adding a `versions.tf`
  (`required_version = "~> 1.15"`, `aws ~> 6.0`), then `init` + `validate`. Scratch root deleted, not
  committed.
- Cross-checked every top-level argument of every `module` block in `examples/*/main.tf` and in the
  README block against the corresponding module's `variables.tf` — no unknown arguments remain.
- Verified the `module.user` key fix with `terraform console` (output above).
- **Not verified:** no `terraform plan` or `apply` was run anywhere (no credentials, and out of scope),
  so nothing here is confirmed against the AWS API. In particular the README's placeholder
  `vpc_id`/`subnet_group` values are syntactically valid but not real resources.
- **Not covered by this sweep:** `modules/rds-aurora-postgresql-cluster` exists only on the unmerged
  `rds-aurora-postgresql-cluster` branch, not on `main`. It has never been through any of these
  sweeps; whoever lands that branch should run the same fmt/init/validate pass over it.
- Unrelated nit noticed and deliberately **not** changed: the README's Examples list links
  `./examples/elasticache-redis-multi-az`, but the directory on disk is `elasticache-redis-muti-az`
  (missing `l`). Renaming the directory or fixing the link is an owner call, not part of this sweep.
